### PR TITLE
Add S3 support

### DIFF
--- a/__tests__/unit/__mocks__.ts
+++ b/__tests__/unit/__mocks__.ts
@@ -101,3 +101,7 @@ export const event: APIGatewayEvent = {
     protocol: 'HTTP/1.1',
   },
 }
+
+export const messageBuffer = Buffer.from(JSON.stringify(email))
+
+export const uuid = 'aaaaa-uuuuu-uuuuu-iiiii-ddddd'

--- a/__tests__/unit/handlers/post-item.test.ts
+++ b/__tests__/unit/handlers/post-item.test.ts
@@ -5,10 +5,13 @@ import status from '../../../src/util/status'
 const mockAddToQueue = jest.fn()
 const mockFormatEmail = jest.fn()
 const mockIsValidEmail = jest.fn()
-jest.mock('@services/sqs', () => ({
+jest.mock('../../../src/services/sqs', () => ({
   addToQueue: (email) => mockAddToQueue(email),
   formatEmail: (email) => mockFormatEmail(email),
   isValidEmail: (email) => mockIsValidEmail(email),
+}))
+jest.mock('../../../src/util/error-handling', () => ({
+  handleErrorWithDefault: (value) => () => value,
 }))
 
 describe('post-item', () => {

--- a/__tests__/unit/handlers/post-item.test.ts
+++ b/__tests__/unit/handlers/post-item.test.ts
@@ -2,6 +2,10 @@ import { email, event } from '../__mocks__'
 import { parseEventBody, postItem } from '../../../src/handlers/post-item'
 import status from '../../../src/util/status'
 
+const mockUploadContentsToS3 = jest.fn()
+jest.mock('../../../src/services/s3', () => ({
+  uploadContentsToS3: (uuid, body) => mockUploadContentsToS3(uuid, body),
+}))
 const mockAddToQueue = jest.fn()
 const mockFormatEmail = jest.fn()
 const mockIsValidEmail = jest.fn()
@@ -39,6 +43,7 @@ describe('post-item', () => {
       mockAddToQueue.mockResolvedValue(undefined)
       mockFormatEmail.mockResolvedValue(email)
       mockIsValidEmail.mockReturnValue(true)
+      mockUploadContentsToS3.mockResolvedValue(undefined)
     })
 
     test('expect NO_CONTENT when everything is valid', async () => {

--- a/__tests__/unit/services/s3.test.ts
+++ b/__tests__/unit/services/s3.test.ts
@@ -1,7 +1,9 @@
 import { S3 } from 'aws-sdk'
 
+import { messageBuffer, uuid } from '../__mocks__'
 import { emailBucket } from '../../../src/config'
-import { putS3Object } from '../../../src/services/s3'
+import * as s3Module from '../../../src/services/s3'
+import { putS3Object, uploadContentsToS3 } from '../../../src/services/s3'
 
 const mockPutObject = jest.fn()
 jest.mock('aws-sdk', () => ({
@@ -16,6 +18,19 @@ jest.mock('../../../src/util/error-handling', () => ({
 
 describe('S3', () => {
   const key = 'prefix/key'
+
+  describe('uploadContentsToS3', () => {
+    const mockPutS3Object = jest.spyOn(s3Module, 'putS3Object')
+
+    beforeEach(() => {
+      mockPutS3Object.mockResolvedValueOnce({})
+    })
+
+    test('expect uuid and body to be passed to putS3Object', async () => {
+      await uploadContentsToS3(uuid, messageBuffer)
+      expect(mockPutS3Object).toHaveBeenCalledWith(`queue/${uuid}`, messageBuffer)
+    })
+  })
 
   describe('putS3Object', () => {
     const metadata = {

--- a/__tests__/unit/services/s3.test.ts
+++ b/__tests__/unit/services/s3.test.ts
@@ -1,0 +1,47 @@
+import { S3 } from 'aws-sdk'
+
+import { emailBucket } from '../../../src/config'
+import { putS3Object } from '../../../src/services/s3'
+
+const mockPutObject = jest.fn()
+jest.mock('aws-sdk', () => ({
+  S3: jest.fn(() => ({
+    putObject: (params: S3.Types.PutObjectRequest) => ({ promise: () => mockPutObject(params) }),
+  })),
+}))
+
+jest.mock('../../../src/util/error-handling', () => ({
+  handleErrorWithDefault: (value) => () => value,
+}))
+
+describe('S3', () => {
+  const key = 'prefix/key'
+
+  describe('putS3Object', () => {
+    const metadata = {
+      'Content-Type': 'text/plain',
+    }
+    const valueToPut = 'Hello, world!'
+
+    test('expect key and data passed to S3 as object', async () => {
+      await putS3Object(key, valueToPut, metadata)
+      expect(mockPutObject).toHaveBeenCalledWith({
+        Body: valueToPut,
+        Bucket: emailBucket,
+        Key: key,
+        Metadata: metadata,
+      })
+    })
+
+    test('expect no metadata passed to S3 when omitted', async () => {
+      await putS3Object(key, valueToPut)
+      expect(mockPutObject).toHaveBeenCalledWith({ Body: valueToPut, Bucket: emailBucket, Key: key, Metadata: {} })
+    })
+
+    test('expect reject when promise rejects', async () => {
+      const rejectReason = 'unable to foo the bar'
+      mockPutObject.mockRejectedValueOnce(rejectReason)
+      await expect(putS3Object(key, valueToPut, metadata)).rejects.toEqual(rejectReason)
+    })
+  })
+})

--- a/__tests__/unit/services/sqs.test.ts
+++ b/__tests__/unit/services/sqs.test.ts
@@ -1,4 +1,4 @@
-import { email } from '../__mocks__'
+import { email, uuid } from '../__mocks__'
 import { sqsQueueUrl } from '../../../src/config'
 import { addToQueue, formatEmail, isValidEmail } from '../../../src/services/sqs'
 
@@ -37,8 +37,9 @@ describe('sqs', () => {
     })
 
     test('expect email to be added to queue', async () => {
-      await addToQueue(email)
-      expect(mockSendMessage).toHaveBeenCalledWith({ MessageBody: JSON.stringify({ email }), QueueUrl: sqsQueueUrl })
+      const body = { uuid }
+      await addToQueue(body)
+      expect(mockSendMessage).toHaveBeenCalledWith({ MessageBody: JSON.stringify(body), QueueUrl: sqsQueueUrl })
     })
   })
 })

--- a/events/post-item.json
+++ b/events/post-item.json
@@ -1,4 +1,4 @@
 {
   "httpMethod": "POST",
-  "body": "{\"from\":\"do-not-reply@bowland.link\",\"sender\":\"do-not-reply@bowland.link\",\"to\":[\"dbowland1@gmail.com\"],\"replyTo\":\"davidthegenius@gmail.com\",\"references\":[],\"subject\":\"Hi there!\",\"text\":\"Hello, world\",\"html\":\"<p>Hello, world</p>\",\"headers\":{\"From\":\"do-not-reply@bowland.link\"}}"
+  "body": "{\"from\":\"do-not-reply@bowland.link\",\"sender\":\"do-not-reply@bowland.link\",\"to\":[\"david@bowland.link\"],\"replyTo\":\"dave@bowland.link\",\"references\":[],\"subject\":\"Hi there!\",\"text\":\"Hello, world\",\"html\":\"<p>Hello, world</p>\",\"headers\":{\"From\":\"do-not-reply@bowland.link\"}}"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.2.0",
       "dependencies": {
         "aws-sdk": "^2.799.0",
-        "fast-json-patch": "^3.1.0"
+        "fast-json-patch": "^3.1.0",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@babel/core": "^7.16.5",
@@ -3111,6 +3112,15 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/babel-jest": {
@@ -8232,16 +8242,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-notifier/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
@@ -10630,12 +10630,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -13249,6 +13248,13 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "babel-jest": {
@@ -17126,13 +17132,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -18975,9 +18974,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.799.0",
-    "fast-json-patch": "^3.1.0"
+    "fast-json-patch": "^3.1.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",
@@ -34,7 +35,8 @@
     "clean": "rm -rf dist coverage && NODE_ENV=test npm ci",
     "lint": "prettier --write . && eslint --fix . --resolve-plugins-relative-to .",
     "prepare": "if [ \"$HUSKY\" != \"0\" ]; then husky install ; fi",
-    "start": "tsc && HUSKY=0 sam build && sam local invoke --event events/post-item.json",
+    "start": "npm run build && npm run quick-start",
+    "quick-start": "tsc && HUSKY=0 sam build && EMAIL_BUCKET=emails-dbowland SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/494887012091/emails-queue-service-SimpleQueue-146A3KUXV7CRG sam local invoke --event events/post-item.json",
     "test": "npm run lint && jest --colors"
   },
   "lint-staged": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,7 @@
+// S3
+
+export const emailBucket = process.env.EMAIL_BUCKET as string
+
 // SQS
 
 export const sqsQueueUrl = process.env.SQS_QUEUE_URL as string

--- a/src/services/s3.ts
+++ b/src/services/s3.ts
@@ -8,6 +8,9 @@ export interface Metadata {
   [key: string]: string
 }
 
+export const uploadContentsToS3 = (uuid: string, body: Buffer | string): Promise<S3.PutObjectOutput> =>
+  exports.putS3Object(`queue/${uuid}`, body)
+
 /* Put */
 
 export const putS3Object = (key: string, body: Buffer | string, metadata: Metadata = {}): Promise<S3.PutObjectOutput> =>

--- a/src/services/s3.ts
+++ b/src/services/s3.ts
@@ -1,0 +1,14 @@
+import { S3 } from 'aws-sdk'
+
+import { emailBucket } from '../config'
+
+const s3 = new S3({ apiVersion: '2006-03-01' })
+
+export interface Metadata {
+  [key: string]: string
+}
+
+/* Put */
+
+export const putS3Object = (key: string, body: Buffer | string, metadata: Metadata = {}): Promise<S3.PutObjectOutput> =>
+  s3.putObject({ Body: body, Bucket: emailBucket, Key: key, Metadata: metadata }).promise()

--- a/src/services/sqs.ts
+++ b/src/services/sqs.ts
@@ -43,10 +43,10 @@ export const isValidEmail = (email: Email): boolean =>
 
 /* Message queue */
 
-export const addToQueue = (email: Email) =>
+export const addToQueue = (data: { [key: string]: string }) =>
   sqs
     .sendMessage({
-      MessageBody: JSON.stringify({ email }),
+      MessageBody: JSON.stringify(data),
       QueueUrl: sqsQueueUrl,
     })
     .promise()

--- a/template.yaml
+++ b/template.yaml
@@ -49,8 +49,13 @@ Resources:
       Timeout: 30
       Description: Adds emails to the queue to be sent.
       Policies:
+        # Give Lambda basic execution Permission
+        - AWSLambdaBasicExecutionRole
+        # Grant access to S3 bucket
+        - S3WritePolicy:
+            BucketName: emails-dbowland
         # Grant access to SQS queue
-        - SQSPollerPolicy:
+        - SQSSendMessagePolicy:
             QueueName: emails-queue-service-SimpleQueue-146A3KUXV7CRG
       Environment:
         Variables:


### PR DESCRIPTION
SQS max size is 256kb, but an email consists of the HTML contents, the text contents, and attachments. Switch to using S3 to store emails and SQS as a marker for those emails.